### PR TITLE
fix(footer): center footer text

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -15,7 +15,8 @@
 .footer {
   display: flex;
   flex: 1;
-  padding: 2rem 0;
+  padding: 2rem;
+  text-align: center;
   border-top: 1px solid #eaeaea;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
Footer was originally left aligned and with no left and right padding.

This made it look bad on mobile, which is why I decided to go for centered text with left and right padding.