### PR TITLE
fix: change wording for antibiotic state question

### DIFF
--- a/components/AntibioticCalculator.tsx
+++ b/components/AntibioticCalculator.tsx
@@ -108,7 +108,7 @@ const AntibioticCalculator = () => {
 
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
-          <p className="">What state is your antibiotic?</p>
+          <p className="">What form is your antibiotic?</p>
 
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
             <ToggleButton

--- a/components/AntibioticCalculator.tsx
+++ b/components/AntibioticCalculator.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, KeyboardEventHandler, useEffect, useState } from "react";
+import { KeyboardEventHandler, useEffect, useState } from "react";
 import QuestionBlock from "./QuestionBlock";
 import ToggleButton from "./ToggleButton";
 


### PR DESCRIPTION
# Changelog

 Change the word "state" to "form" for asking if the antibiotic is liquid or powder. The word form just fits better for me rather than state.