### PR TITLE
fix: swap font when loaded

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "../styles/globals.css";
 const notoSansMono = Noto_Sans_Mono({
   subsets: ["latin", "greek"],
   variable: "--font-noto-sans-mono",
+  display: "swap",
 });
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Head from "next/head";
 import AgarCalculator from "../components/AgarCalculator";
 import Navbar from "../components/Navbar";
 


### PR DESCRIPTION
## Changelog

Sometimes the font would not load properly on the initial page load. This could be replicated by disabling browser cache and refreshing a number of times.

Specified display swap for next font.